### PR TITLE
change the theorion-i18n func in i18n.typ for better region-level localization

### DIFF
--- a/examples/example-tw.typ
+++ b/examples/example-tw.typ
@@ -1,0 +1,72 @@
+#import "../lib.typ": *
+
+#set text(lang: "zh",region: "tw")
+
+#let cn-font-serif = "Source Han Serif SC"  // 思源宋体
+#let en-font-serif = "New Computer Modern"
+#let cn-font-sans = "Source Han Sans SC"  // 思源黑体
+#let en-font-sans = "New Computer Modern Sans"
+#let default-thmprefix(t, color: rgb("#000000")) = {
+  text(font: (en-font-sans, cn-font-sans), weight: 650, fill: color)[#t]
+}
+#let default-thmtitle(t, color: rgb("#000000")) = {
+  text(font: (en-font-sans, cn-font-sans), weight: 350, fill: color)[#t]
+}
+#let default-thmtext(t, color: rgb("#000000")) = {
+  let a = t.children
+  if (a.at(0) == [ ]) {
+    a.remove(0)
+  }
+  t = a.join()
+
+  text(font: (en-font-serif, cn-font-serif), fill: color)[#t]
+}
+
+// 定义定理环境的样式
+#let round-box-style(
+  prefix: auto,
+  title: "",
+  full-title: auto,
+  fill: luma(500),
+  thmtitle: default-thmtitle,
+  thmtext: default-thmtext,
+  thmprefix: default-thmprefix,
+  body,
+) = {
+  let titlefmt = thmtitle.with(color: white)
+  let bodyfmt = thmtext
+  let prefixfmt = thmprefix.with(color: white)
+
+  showybox(
+    title: [#prefixfmt(prefix) #titlefmt(title)],
+    width: 100%,
+    radius: 0.3em,
+    breakable: false,
+    frame: (
+      title-color: fill,
+      border-color: fill.darken(10%),
+    ),
+    shadow: (
+      color: luma(220),
+      offset: 3pt,
+    ),
+    [
+      #set par(first-line-indent: 2em)
+      #bodyfmt(body)
+    ],
+  )
+}
+
+#let (definition-counter, definition-box, definition, show-definition) = make-frame(
+  "definition",
+  theorion-i18n(theorion-i18n-map.definition),
+  inherited-levels: 2,
+  inherited-from: heading,
+  render: round-box-style.with(fill: rgb("#255C99")),
+)
+
+#show: show-definition
+
+#definition(title: [勾股定理])[
+  在直角三角形中，斜边的平方等于两条直角边的平方和.
+]

--- a/i18n.typ
+++ b/i18n.typ
@@ -18,8 +18,9 @@
       if type(map.at(text.lang)) != dictionary {
         value = map.at(text.lang)
       } else {
-        if text.region != none and text.region in map.at(text.lang) {
-          value = map.at(text.lang).at(text.region)
+        let tr = lower(text.region)
+        if tr != none and tr in map.at(text.lang) {
+          value = map.at(text.lang).at(tr)
         } else {
           value = map.at(text.lang).values().at(0, default: value)
         }

--- a/i18n.typ
+++ b/i18n.typ
@@ -18,9 +18,8 @@
       if type(map.at(text.lang)) != dictionary {
         value = map.at(text.lang)
       } else {
-        let tr = lower(text.region)
-        if tr != none and tr in map.at(text.lang) {
-          value = map.at(text.lang).at(tr)
+        if text.region != none and lower(text.region) in map.at(text.lang) {
+          value = map.at(text.lang).at(lower(text.region))
         } else {
           value = map.at(text.lang).values().at(0, default: value)
         }


### PR DESCRIPTION
the `text.lang` is all in lower case, but `text.region` is in upper case, 
so the original translation dict's key didn't work well, 
now when the `text.region` is not none, we lowercase it to match the dict's key
and i add example.typ to examiine this, which can be deleted ;)
