### PR TITLE
i18n: swedish translation of note: replace "anmärkning" with "kommentar"

### DIFF
--- a/i18n.typ
+++ b/i18n.typ
@@ -100,7 +100,7 @@
     it: "Osservazione",
     vi: "Ghi chú",
     pl: "Dopisek",
-    sv: "Anmärkning", // Not
+    sv: "Kommentar", // Not, anmärkning
   ),
   warning: (
     en: (us: "Warning", gb: "Warning"),


### PR DESCRIPTION
The Swedish translation currently uses _anmärkning_ for both `note` and `remark`. For variation, instead translate `note` as _kommentar_ (lit. _comment_).